### PR TITLE
Add the `snippet_prefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Dynamic parameters:
 {% include_file "{{ $templatingAllowedHere }}/Dockerfile" snippet="{{ $hereToo }}" %}
 ```
 
+## Plugin options in `_config.yml`
+
+Default options:
+```yml
+jekyll_include_plugin:
+  snippet_prefix: '...'
+```
+
+### `snippet_prefix`
+Type: `string` Default: `...`
+
+Prepends the prefix at the end of included snippet to differentiate whole file includes vs partial file includes (snippet)  
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/jekyll_include_plugin/jekyll_include_plugin.rb
+++ b/lib/jekyll_include_plugin/jekyll_include_plugin.rb
@@ -21,7 +21,7 @@ module JekyllIncludePlugin
       file_contents = get_raw_file_contents(context)
 
       if @params["snippet"]
-        file_contents = pick_snippet(file_contents, @config, @params["snippet"])
+        file_contents = pick_snippet(file_contents, @config['snippet_prefix'], @params["snippet"])
       else
         file_contents = remove_all_snippets(file_contents)
       end

--- a/lib/jekyll_include_plugin/jekyll_include_plugin.rb
+++ b/lib/jekyll_include_plugin/jekyll_include_plugin.rb
@@ -10,16 +10,18 @@ module JekyllIncludePlugin
     def initialize(tag_name, raw_markup, tokens)
       super
       @raw_markup = raw_markup
+      @config = {}
       @params = {}
     end
 
     def render(context)
+      read_config(context)
       parse_params(context)
 
       file_contents = get_raw_file_contents(context)
 
       if @params["snippet"]
-        file_contents = pick_snippet(file_contents, @params["snippet"])
+        file_contents = pick_snippet(file_contents, @config, @params["snippet"])
       else
         file_contents = remove_all_snippets(file_contents)
       end
@@ -33,6 +35,13 @@ module JekyllIncludePlugin
     end
 
     private
+
+    def read_config(context)
+      site = context.registers[:site]
+      plugin_config = site.config["jekyll_include_plugin"] || {}
+
+      @config["snippet_prefix"] = plugin_config['snippet_prefix'] || '...'
+    end
 
     def parse_params(context)
       rendered_markup = Liquid::Template

--- a/lib/jekyll_include_plugin/utils.rb
+++ b/lib/jekyll_include_plugin/utils.rb
@@ -16,7 +16,7 @@ module JekyllIncludePlugin
   module TextUtils
     include Utils
 
-    def pick_snippet(text, config, snippet_name)
+    def pick_snippet(text, snippet_prefix, snippet_name)
       snippet_content = ""
       snippet_start_found = false
       snippet_end_found = false
@@ -41,8 +41,6 @@ module JekyllIncludePlugin
       abort("Snippet '#{snippet_name}' has not been found.") unless snippet_start_found
       abort("End of the snippet '#{snippet_name}' has not been found.") unless snippet_end_found
       abort("Snippet '#{snippet_name}' appears to be empty. Fix and retry.") if snippet_content.empty?
-
-      snippet_prefix = config['snippet_prefix']
 
       return snippet_content if snippet_prefix.empty?
 

--- a/lib/jekyll_include_plugin/utils.rb
+++ b/lib/jekyll_include_plugin/utils.rb
@@ -42,8 +42,7 @@ module JekyllIncludePlugin
       abort("End of the snippet '#{snippet_name}' has not been found.") unless snippet_end_found
       abort("Snippet '#{snippet_name}' appears to be empty. Fix and retry.") if snippet_content.empty?
 
-      first_line_indent = %r!^\s*!.match(snippet_content)[0]
-      return "#{first_line_indent}...\n#{snippet_content}"
+      return snippet_content
     end
 
     def remove_all_snippets(text)

--- a/lib/jekyll_include_plugin/utils.rb
+++ b/lib/jekyll_include_plugin/utils.rb
@@ -16,7 +16,7 @@ module JekyllIncludePlugin
   module TextUtils
     include Utils
 
-    def pick_snippet(text, snippet_name)
+    def pick_snippet(text, config, snippet_name)
       snippet_content = ""
       snippet_start_found = false
       snippet_end_found = false
@@ -42,7 +42,12 @@ module JekyllIncludePlugin
       abort("End of the snippet '#{snippet_name}' has not been found.") unless snippet_end_found
       abort("Snippet '#{snippet_name}' appears to be empty. Fix and retry.") if snippet_content.empty?
 
-      return snippet_content
+      snippet_prefix = config['snippet_prefix']
+
+      return snippet_content if snippet_prefix.empty?
+
+      first_line_indent = %r!^\s*!.match(snippet_content)[0]
+      return "#{first_line_indent}#{snippet_prefix}\n#{snippet_content}"
     end
 
     def remove_all_snippets(text)


### PR DESCRIPTION
The PR adds the `snippet_prefix` option to the `_config.yml` that can be used to set a prefix for snippets

Default value:
```
jekyll_include_plugin:
    snippet_prefix: '...'
```

Remove snippet prefix
```
jekyll_include_plugin:
    snippet_prefix: ''
```

Fixes https://github.com/flant/jekyll_include_plugin/issues/12