### PR TITLE
Add the `[<ignore>]` syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+.idea

--- a/README.md
+++ b/README.md
@@ -60,6 +60,37 @@ Dynamic parameters:
 {% include_file "{{ $templatingAllowedHere }}/Dockerfile" snippet="{{ $hereToo }}" %}
 ```
 
+## Ignore a part of an included content
+
+The usage:
+```jsx
+const template = () => {
+  return (
+    // [<snippet example>]
+    <Provider
+      // [<ignore>]
+      propToIgnore={propToIgnore}
+      // [<endignore>]
+      component={() => <div>Data is loading...</div>}
+      errorComponent={({ message }) => <div>There was an error: {message}</div>}
+    >
+      ...
+    </Provider>
+    // [<endsnippet example>]
+  );
+};
+```
+
+The result:
+```jsx
+  <Provider
+    component={() => <div>Data is loading...</div>}
+    errorComponent={({ message }) => <div>There was an error: {message}</div>}
+  >
+    ...
+  </Provider>
+```
+
 ## Plugin options in `_config.yml`
 
 Default options:

--- a/lib/jekyll_include_plugin/jekyll_include_plugin.rb
+++ b/lib/jekyll_include_plugin/jekyll_include_plugin.rb
@@ -26,6 +26,7 @@ module JekyllIncludePlugin
         file_contents = remove_all_snippets(file_contents)
       end
 
+      file_contents = remove_ignored_lines(file_contents)
       file_contents = remove_excessive_newlines(file_contents)
       file_contents = remove_excessive_indentation(file_contents)
       file_contents = render_comments(file_contents, context.registers[:page]["lang"])

--- a/lib/jekyll_include_plugin/utils.rb
+++ b/lib/jekyll_include_plugin/utils.rb
@@ -48,6 +48,21 @@ module JekyllIncludePlugin
       return "#{first_line_indent}#{snippet_prefix}\n#{snippet_content}"
     end
 
+    def remove_ignored_lines(text)
+      ignoring = false
+      text.each_line.reject do |line|
+        if line =~ /^\s*\/\/\s*\[<ignore>\]/
+          ignoring = true
+          true
+        elsif line =~ /^\s*\/\/\s*\[<endignore>\]/
+          ignoring = false
+          true
+        else
+          ignoring
+        end
+      end.join
+    end
+
     def remove_all_snippets(text)
       result_text = ""
       text.each_line do |line|

--- a/spec/jekyll_include_plugin_spec.rb
+++ b/spec/jekyll_include_plugin_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe JekyllIncludePlugin do
     arr
   end
 
-  let(:raw_markup) { 'dummy.md snippet="imports"' }
+  let(:raw_markup) { 'dummy.md snippet="example"' }
   let(:tag) do
     JekyllIncludePlugin::IncludeFileTag.send(:new, "include_file", raw_markup, dummy_tokens)
   end
@@ -33,10 +33,10 @@ RSpec.describe JekyllIncludePlugin do
       let(:text) do
         <<~TEXT
           Some intro text
-          [<snippet imports>]
+          [<snippet example>]
           line1
           line2
-          [<endsnippet imports>]
+          [<endsnippet example>]
           Some other text
         TEXT
       end
@@ -59,7 +59,7 @@ RSpec.describe JekyllIncludePlugin do
           <<~TEXT
             Some intro text
             line1
-            [<endsnippet imports>]
+            [<endsnippet example>]
             Some other text
           TEXT
         end
@@ -74,7 +74,7 @@ RSpec.describe JekyllIncludePlugin do
         let(:text) do
           <<~TEXT
             Some intro text
-            [<snippet imports>]
+            [<snippet example>]
             line1
             line2
             Some other text
@@ -90,8 +90,8 @@ RSpec.describe JekyllIncludePlugin do
       context "when snippet content is empty" do
         let(:text) do
           <<~TEXT
-            [<snippet imports>]
-            [<endsnippet imports>]
+            [<snippet example>]
+            [<endsnippet example>]
           TEXT
         end
 
@@ -104,11 +104,11 @@ RSpec.describe JekyllIncludePlugin do
       context "when the snippet appears twice" do
         let(:text) do
           <<~TEXT
-            [<snippet imports>]
+            [<snippet example>]
             line1
-            [<snippet imports>]
+            [<snippet example>]
             line2
-            [<endsnippet imports>]
+            [<endsnippet example>]
           TEXT
         end
 
@@ -130,10 +130,10 @@ RSpec.describe JekyllIncludePlugin do
       let(:text) do
         <<~TEXT
           Some intro text
-          [<snippet imports>]
+          [<snippet example>]
           line1
           line2
-          [<endsnippet imports>]
+          [<endsnippet example>]
           Some other text
         TEXT
       end
@@ -168,18 +168,21 @@ RSpec.describe JekyllIncludePlugin do
       let(:text) do
         <<~TEXT
           line before
+          // [<snippet example>]
+          line 1
           // [<ignore>]
           line to ignore 1
           line to ignore 2
           // [<endignore>]
+          line 2
+          // [<endsnippet example>]
           line after
         TEXT
       end
 
       it "removes the ignore markers and all lines between them" do
         allow(tag).to receive(:get_raw_file_contents).and_return(text)
-        allow(tag).to receive(:pick_snippet).with(text, "...", "imports").and_return(text)
-        expect(tag.render(dummy_context)).to eq("line before\nline after")
+        expect(tag.render(dummy_context)).to eq("...\nline 1\nline 2")
       end
     end
   end

--- a/spec/jekyll_include_plugin_spec.rb
+++ b/spec/jekyll_include_plugin_spec.rb
@@ -1,7 +1,186 @@
 # frozen_string_literal: true
+require "jekyll"
+require "liquid"
 
 RSpec.describe JekyllIncludePlugin do
+  let(:dummy_site) do
+    double(
+      "site",
+      config: { "jekyll_include_plugin" => { "snippet_prefix" => "..." }, "source" => __dir__ },
+      file_read_opts: {}
+    )
+  end
+  let(:dummy_registers) { { site: dummy_site, page: { "lang" => "en" } } }
+  let(:dummy_context) { Liquid::Context.new({}, {}, dummy_registers) }
+
+  let(:dummy_tokens) do
+    arr = []
+    def arr.line_number; 1; end
+    arr
+  end
+
+  let(:raw_markup) { 'dummy.md snippet="imports"' }
+  let(:tag) do
+    JekyllIncludePlugin::IncludeFileTag.send(:new, "include_file", raw_markup, dummy_tokens)
+  end
+
   it "has a version number" do
     expect(JekyllIncludePlugin::VERSION).not_to be nil
+  end
+
+  describe "#render" do
+    context "when snippet markers are correct" do
+      let(:text) do
+        <<~TEXT
+          Some intro text
+          [<snippet imports>]
+          line1
+          line2
+          [<endsnippet imports>]
+          Some other text
+        TEXT
+      end
+
+      it "returns the snippet content" do
+        allow(tag).to receive(:get_raw_file_contents).and_return(text)
+        expect(tag.render(dummy_context)).to eq("...\nline1\nline2")
+      end
+    end
+
+    describe "error handling" do
+      before do
+        allow(Jekyll.logger).to receive(:abort_with) do |prefix, msg|
+          raise SystemExit, "#{prefix} #{msg}"
+        end
+      end
+
+      context "when the snippet start marker is missing" do
+        let(:text) do
+          <<~TEXT
+            Some intro text
+            line1
+            [<endsnippet imports>]
+            Some other text
+          TEXT
+        end
+
+        it "aborts with a snippet not found error" do
+          allow(tag).to receive(:get_raw_file_contents).and_return(text)
+          expect { tag.render(dummy_context) }.to raise_error(SystemExit)
+        end
+      end
+
+      context "when the snippet end marker is missing" do
+        let(:text) do
+          <<~TEXT
+            Some intro text
+            [<snippet imports>]
+            line1
+            line2
+            Some other text
+          TEXT
+        end
+
+        it "aborts with an end marker not found error" do
+          allow(tag).to receive(:get_raw_file_contents).and_return(text)
+          expect { tag.render(dummy_context) }.to raise_error(SystemExit)
+        end
+      end
+
+      context "when snippet content is empty" do
+        let(:text) do
+          <<~TEXT
+            [<snippet imports>]
+            [<endsnippet imports>]
+          TEXT
+        end
+
+        it "aborts because the snippet content appears empty" do
+          allow(tag).to receive(:get_raw_file_contents).and_return(text)
+          expect { tag.render(dummy_context) }.to raise_error(SystemExit)
+        end
+      end
+
+      context "when the snippet appears twice" do
+        let(:text) do
+          <<~TEXT
+            [<snippet imports>]
+            line1
+            [<snippet imports>]
+            line2
+            [<endsnippet imports>]
+          TEXT
+        end
+
+        it "aborts because the snippet occurs twice" do
+          allow(tag).to receive(:get_raw_file_contents).and_return(text)
+          expect { tag.render(dummy_context) }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    context "when snippet_prefix is empty" do
+      let(:dummy_site) do
+        double(
+          "site",
+          config: { "jekyll_include_plugin" => { "snippet_prefix" => "" }, "source" => __dir__ }
+        )
+      end
+
+      let(:text) do
+        <<~TEXT
+          Some intro text
+          [<snippet imports>]
+          line1
+          line2
+          [<endsnippet imports>]
+          Some other text
+        TEXT
+      end
+
+      it "returns the snippet content" do
+        allow(tag).to receive(:get_raw_file_contents).and_return(text)
+        expect(tag.render(dummy_context)).to eq("line1\nline2")
+      end
+    end
+
+    context "with ignore markers and full file include" do
+      let(:text) do
+        <<~TEXT
+          line before
+          // [<ignore>]
+          line to ignore 1
+          line to ignore 2
+          // [<endignore>]
+          line after
+        TEXT
+      end
+
+      let(:raw_markup) { 'dummy.md' }
+
+      it "removes the ignore markers and all lines between them" do
+        allow(tag).to receive(:get_raw_file_contents).and_return(text)
+        expect(tag.render(dummy_context)).to eq("line before\nline after")
+      end
+    end
+
+    context "with ignore markers and a snippet include" do
+      let(:text) do
+        <<~TEXT
+          line before
+          // [<ignore>]
+          line to ignore 1
+          line to ignore 2
+          // [<endignore>]
+          line after
+        TEXT
+      end
+
+      it "removes the ignore markers and all lines between them" do
+        allow(tag).to receive(:get_raw_file_contents).and_return(text)
+        allow(tag).to receive(:pick_snippet).with(text, "...", "imports").and_return(text)
+        expect(tag.render(dummy_context)).to eq("line before\nline after")
+      end
+    end
   end
 end


### PR DESCRIPTION
For our case, we need the support of the `[<ignore>]` syntax.

```
const template = () => {
  return (
    // [<snippet example>]
    <Provider
      // [<ignore>]
      propToIgnore={propToIgnore}
      // [<endignore>]
      component={() => <div>Data is loading...</div>}
      errorComponent={({ message }) => <div>There was an error: {message}</div>}
    >
       <div>...</div>
    </Provider>
    // [<endsnippet example>]
  );
};
```

So the result is:
```
    <Provider
      component={() => <div>Data is loading...</div>}
      errorComponent={({ message }) => <div>There was an error: {message}</div>}
    >
       <div>...</div>
    </Provider>
```

So, what we want is to exclude a subset of an imported snippet.
Also I added a few tests

Fixes https://github.com/flant/jekyll_include_plugin/issues/14